### PR TITLE
Add README instructions and fix daemon path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# Novari Flask Application
+
+## Prerequisites
+
+- Python 3.10+ and `pip`
+- MariaDB or MySQL server
+- (optional) nginx if using `start_site_demon.sh`
+
+## Setup
+
+1. **Clone the repository** and navigate into it.
+2. **Create and activate a virtual environment**:
+   ```bash
+   python3 -m venv flaskenv
+   source flaskenv/bin/activate
+   ```
+3. **Install dependencies** (if a `requirements.txt` is added, install from it). Currently the virtual environment directory `flaskenv/` is committed for convenience, but creating your own is recommended.
+
+### Environment variables
+
+Set the following variables before running the app:
+
+- `SECRET_KEY` – Flask secret key.
+- `SQLALCHEMY_DATABASE_URI` – database connection string (e.g. `mysql+mysqlconnector://user:pass@localhost/novari_06`).
+- `FLASK_APP` – entry point (`main.py`).
+- `FLASK_ENV` – `development` or `production`.
+
+You can export them in your shell or store them in an `.env` file loaded by your environment manager.
+
+### Database initialization
+
+Create the database and tables using the provided SQL dump:
+
+```bash
+mysql -u <user> -p < db/novari_06.sql
+```
+
+Alternatively, start the app once and SQLAlchemy will create tables automatically if the database exists.
+
+## Running the application
+
+Activate your virtual environment and start the Flask development server:
+
+```bash
+source flaskenv/bin/activate
+flask run --host 0.0.0.0 --port 5000
+```
+
+This uses the environment variables defined above. The application code also defines `app.run` in `main.py` which will run on port 80 if executed directly with `python main.py`.
+
+## Optional helper script
+
+The repository contains `start_site_demon.sh` which launches the app with Gunicorn and restarts nginx. The script automatically locates the project directory based on its own location, so you can run it from anywhere.
+
+Make the script executable and run it when needed:
+
+```bash
+chmod +x start_site_demon.sh
+./start_site_demon.sh
+```
+
+Run it only if you have Gunicorn, nginx and MariaDB configured locally.

--- a/start_site_demon.sh
+++ b/start_site_demon.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
+set -e
 
 echo "🔄 Starting Flask app behind Gunicorn..."
 sudo systemctl start mariadb
-# Move to your project directory
-cd ~/novaribb || {
+# Determine project directory (directory of this script)
+PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$PROJECT_DIR" || {
   echo "❌ Project folder not found!"
   exit 1
 }
 
 # Activate virtual environment
-if [ -f ~/flaskenv/bin/activate ]; then
-  source ~/flaskenv/bin/activate
+if [ -f "$PROJECT_DIR/flaskenv/bin/activate" ]; then
+  source "$PROJECT_DIR/flaskenv/bin/activate"
 else
-  echo "❌ Virtual environment not found at ~/flaskenv"
+  echo "❌ Virtual environment not found at $PROJECT_DIR/flaskenv"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- document setup, environment variables, database initialization and how to run the Flask app
- explain the optional `start_site_demon.sh` script
- correct project path in the daemon script
- show how to execute the helper script
- make the demon script self-contained to automatically find the project root and virtualenv

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68446316d8e8832493cad534f59be39d